### PR TITLE
fix: make "options" optional for YouTube const and Video#fetch

### DIFF
--- a/src/YouTube.ts
+++ b/src/YouTube.ts
@@ -23,7 +23,7 @@ export class YouTube {
 	public constructor(key: string, options?: Options) {
 		this.#key = key;
 		this.options = {
-			cache: (options ? options.cache : true) || true,
+			cache: options?.cache || true,
 			fetchAll: (options ? options.fetchAll : false) || false
 		};
 	}

--- a/src/YouTube.ts
+++ b/src/YouTube.ts
@@ -24,7 +24,7 @@ export class YouTube {
 		this.#key = key;
 		this.options = {
 			cache: options?.cache || true,
-			fetchAll: (options ? options.fetchAll : false) || false
+			fetchAll: options?.fetchAll || false
 		};
 	}
 

--- a/src/YouTube.ts
+++ b/src/YouTube.ts
@@ -20,11 +20,11 @@ export class YouTube {
 
 	readonly #key: string;
 
-	public constructor(key: string, options: Options) {
+	public constructor(key: string, options?: Options) {
 		this.#key = key;
 		this.options = {
-			cache: options.cache || true,
-			fetchAll: options.fetchAll || false
+			cache: (options ? options.cache : true) || true,
+			fetchAll: (options ? options.fetchAll : false) || false
 		};
 	}
 

--- a/src/structures/Video.ts
+++ b/src/structures/Video.ts
@@ -57,7 +57,7 @@ export class Video extends Resource {
 		return null;
 	}
 
-	public async fetch(options: any): Promise<Video> {
+	public async fetch(options: any = {}): Promise<Video> {
 		const video = await this.yt.getVideoById(this.id, options);
 		return this.patch(video);
 	}


### PR DESCRIPTION
This fixes the following issue during TypeScript compilation: "2 arguments required but only 1 present" with the following code:
```ts
import { YouTube } from "simple-youtube-api";
new YouTube("API KEY");
```